### PR TITLE
Support displaying field values on account details page

### DIFF
--- a/src/PMPro/Objects/Member_Profile.php
+++ b/src/PMPro/Objects/Member_Profile.php
@@ -47,6 +47,7 @@ class Member_Profile {
 	 */
 	public function hook() {
 		add_action( 'pmpro_show_user_profile', [ $this, 'pmpro_show_user_profile' ] );
+		add_action( 'pmpro_account_bullets_bottom', [ $this, 'pmpro_account_bullets_bottom' ] );
 		add_action( 'pmpro_add_member_fields', [ $this, 'pmpro_add_member_fields' ] );
 		add_action( 'show_user_profile', [ $this, 'show_user_profile' ] );
 		add_action( 'edit_user_profile', [ $this, 'edit_user_profile' ] );
@@ -93,6 +94,49 @@ class Member_Profile {
 			'heading'       => 'h3',
 			'separator'     => 'off',
 		] );
+	}
+
+	/**
+	 * Render the fields for the frontend user profile form.
+	 *
+	 * @since TBD
+	 */
+	public function pmpro_account_bullets_bottom() {
+		$item_id = get_current_user_id();
+
+		$pod = pods( 'pmpro_membership_user', $item_id );
+
+		$groups = pods_form_get_visible_objects( $pod, [
+			'section_field' => 'pmpro_section_member_profile',
+			'section'       => 'show_on_account',
+			'return_type'   => 'group',
+		] );
+
+		foreach ( $groups as $group ) {
+			$fields = $group->get_fields();
+
+			if ( ! empty( $group['pmpro_account_display_group_label'] ) ) {
+				printf(
+					'</ul><p>%s</p><ul>',
+					esc_html( $group['label'] )
+				);
+			}
+
+			foreach ( $fields as $field ) {
+				$value = $pod->display( $field['name'] );
+
+				// Skip empty values.
+				if ( empty( $value ) ) {
+					continue;
+				}
+
+				printf(
+					'<li><strong>%1$s:</strong> %2$s</li>',
+					esc_html( $field['label'] ),
+					$value
+				);
+			}
+		}
 	}
 
 	/**

--- a/src/PMPro/Objects/Member_Profile.php
+++ b/src/PMPro/Objects/Member_Profile.php
@@ -106,6 +106,11 @@ class Member_Profile {
 
 		$pod = pods( 'pmpro_membership_user', $item_id );
 
+		// Check if Pod is valid and the item exists.
+		if ( ! $pod->valid() || ! $pod->exists() ) {
+			return;
+		}
+
 		$groups = pods_form_get_visible_objects( $pod, [
 			'section_field' => 'pmpro_section_member_profile',
 			'section'       => 'show_on_account',

--- a/src/Pods/Integration.php
+++ b/src/Pods/Integration.php
@@ -497,14 +497,28 @@ class Integration {
 				'help'             => __( 'All available fields in this group will show in the sections chosen.', 'pmpro-pods' ),
 				'type'             => 'pick',
 				'data'             => [
-					'show_on_front' => __( 'Front-facing Profile', 'pmpro-pods' ),
-					'show_on_admin' => __( 'WP Dashboard Profile', 'pmpro-pods' ),
+					'show_on_account' => __( 'Display field values on Account Details Page', 'pmpro-pods' ),
+					'show_on_front'   => __( 'Front-facing Profile Edit', 'pmpro-pods' ),
+					'show_on_admin'   => __( 'WP Dashboard Profile Edit', 'pmpro-pods' ),
 				],
 				'default'          => [
+					'show_on_account',
 					'show_on_front',
 					'show_on_admin',
 				],
 				'pick_format_type' => 'multi',
+			];
+
+			// @todo Fix the pick multi checkboxes dependency issue in Pods core, show_on_account isn't getting picked up here.
+			$options['pmpro']['pmpro_account_display_group_label'] = [
+				'name'       => 'pmpro_account_display_group_label',
+				'label'      => __( 'Display Group Label above fields on Account Details', 'pmpro-pods' ),
+				'help'       => __( 'If enabled, this will display the group label above the fields on Account Details. When disabled, only the field values will be displayed without separation.', 'pmpro-pods' ),
+				'type'       => 'boolean',
+				'default'    => 0,
+				'depends-on' => [
+					'pmpro_section_member_profile' => 'show_on_account',
+				],
 			];
 
 			$options['pmpro']['pmpro_section_checkout'] = [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pods/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pods/pulls/) for the same update/change?

### Changes proposed in this Pull Request:

Add support for displaying field values on the Membership Account page under the Account Details section. This was requested by folks who want this as they dive into the Add On and see it lacking in this regard.

### How to test the changes in this Pull Request:

1. Edit Group for PMPro Member pod and enable Display on Account Details
2. Go to Membership Account page for account that has PMPro Member pod field(s) filled in
3. See display of field(s)

![Screen Shot 2021-11-11 at 5 04 53 PM](https://user-images.githubusercontent.com/709662/141381524-c710a136-f500-415a-8233-501a6abbf239.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added support for displaying field values on the Membership Account page under the Account Details section.
