### PR TITLE
PMPro Pods 1.0.2

### DIFF
--- a/pmpro-pods.php
+++ b/pmpro-pods.php
@@ -3,7 +3,7 @@
 Plugin Name: Paid Memberships Pro - Pods Add On
 Plugin URI: https://www.paidmembershipspro.com/add-ons/pods-integration/
 Description: Integrates Paid Memberships Pro with the Pods Framework to add groups of fields to many areas of your membership site including Member Profiles, the Membership Checkout page, and admin screens including Membership Levels and Orders.
-Version: 1.0.1
+Version: 1.0.2
 Author: Paid Memberships Pro
 Author URI: https://www.paidmembershipspro.com/
 Text Domain: pmpro-pods
@@ -19,7 +19,7 @@ use PMPro_Pods\Pods\Integration;
 use PMPro_Pods\Pods\Meta_Compatibility;
 use PMPro_Pods\Pods\Permissions;
 
-define( 'PMPRO_PODS_VERSION', '1.0.1' );
+define( 'PMPRO_PODS_VERSION', '1.0.2' );
 define( 'PMPRO_PODS_URL', plugin_dir_url( __FILE__ ) );
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -87,9 +87,14 @@ Please visit our premium support site at [https://www.paidmembershipspro.com](ht
 
 == Changelog ==
 
+= 1.0.2 - January 4th, 2022 =
+* ENHANCEMENT: Added support for two new locations on the PMPro checkout page: After User Fields and Checkout Boxes. (@sc0ttkclark)
+* BUG FIX: Improved appearance of Pods fields on the PMPro checkout page so they more closely match styles used by PMPro. (@sc0ttkclark)
+* BUG FIX: Prevent PHP notices from usage of certain PMPro hooks when `$user` object is not passed in. (@sc0ttkclark)
+
 = 1.0.1 - November 12th, 2021 =
-* Added support for showing PMPro Member fields on the Membership Account page under the Account Details area. #5 (@sc0ttkclark)
-* Prevent PHP notices on checkout page when logged out. (@sc0ttkclark)
+* ENHANCEMENT: Added support for showing PMPro Member fields on the Membership Account page under the Account Details area. #5 (@sc0ttkclark)
+* BUG FIX: Prevent PHP notices on checkout page when logged out. (@sc0ttkclark)
 
 = 1.0 - October 26th, 2021 =
 * Initial release

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: paid memberships pro, pods
 Requires at least: 5.5
 Tested up to: 5.8
 Requires PHP: 5.6
-Stable tag: 1.0.1
+Stable tag: 1.0.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,7 @@ Please visit our premium support site at [https://www.paidmembershipspro.com](ht
 * ENHANCEMENT: Added support for two new locations on the PMPro checkout page: After User Fields and Checkout Boxes. (@sc0ttkclark)
 * BUG FIX: Improved appearance of Pods fields on the PMPro checkout page so they more closely match styles used by PMPro. (@sc0ttkclark)
 * BUG FIX: Prevent PHP notices from usage of certain PMPro hooks when `$user` object is not passed in. (@sc0ttkclark)
+* BUG FIX: Prevent PHP notices on the PMPro checkout page when the PMPro Member pod does not exist and has not yet been extended. (@sc0ttkclark)
 
 = 1.0.1 - November 12th, 2021 =
 * ENHANCEMENT: Added support for showing PMPro Member fields on the Membership Account page under the Account Details area. #5 (@sc0ttkclark)

--- a/src/PMPro/Objects/Member_Checkout.php
+++ b/src/PMPro/Objects/Member_Checkout.php
@@ -56,6 +56,8 @@ class Member_Checkout {
 		add_action( 'pmpro_checkout_after_username', [ $this, 'pmpro_checkout_after_username' ] );
 		add_action( 'pmpro_checkout_after_password', [ $this, 'pmpro_checkout_after_password' ] );
 		add_action( 'pmpro_checkout_after_email', [ $this, 'pmpro_checkout_after_email' ] );
+		add_action( 'pmpro_checkout_after_user_fields', [ $this, 'pmpro_checkout_after_user_fields' ] );
+		add_action( 'pmpro_checkout_boxes', [ $this, 'pmpro_checkout_boxes' ] );
 		add_action( 'pmpro_checkout_after_billing_fields', [ $this, 'pmpro_checkout_after_billing_fields' ] );
 		add_action( 'pmpro_checkout_after_payment_information_fields', [ $this, 'pmpro_checkout_after_payment_information_fields' ] );
 		add_action( 'pmpro_checkout_after_tos_fields', [ $this, 'pmpro_checkout_after_tos_fields' ] );
@@ -84,6 +86,8 @@ class Member_Checkout {
 		remove_action( 'pmpro_checkout_after_username', [ $this, 'pmpro_checkout_after_username' ] );
 		remove_action( 'pmpro_checkout_after_password', [ $this, 'pmpro_checkout_after_password' ] );
 		remove_action( 'pmpro_checkout_after_email', [ $this, 'pmpro_checkout_after_email' ] );
+		remove_action( 'pmpro_checkout_after_user_fields', [ $this, 'pmpro_checkout_after_user_fields' ] );
+		remove_action( 'pmpro_checkout_boxes', [ $this, 'pmpro_checkout_boxes' ] );
 		remove_action( 'pmpro_checkout_after_billing_fields', [ $this, 'pmpro_checkout_after_billing_fields' ] );
 		remove_action( 'pmpro_checkout_after_payment_information_fields', [ $this, 'pmpro_checkout_after_payment_information_fields' ] );
 		remove_action( 'pmpro_checkout_after_tos_fields', [ $this, 'pmpro_checkout_after_tos_fields' ] );
@@ -114,10 +118,18 @@ class Member_Checkout {
 		}
 
 		pods_form_render_fields( 'pmpro_membership_user', $user ? $user->ID : null, [
-			'section_field' => 'pmpro_section_checkout',
-			'section'       => 'after_level_cost',
-			'render'        => 'div-rows',
-			'heading'       => 'h3',
+			'section_field'               => 'pmpro_section_checkout',
+			'section'                     => 'after_level_cost',
+			'render'                      => 'div-rows',
+			'wrapper'                     => true,
+			'wrapper_class'               => [
+				'pmpro_checkout',
+				__FUNCTION__,
+			],
+			'container_class'             => 'pmpro_checkout-fields',
+			'heading'                     => 'h3',
+			'heading_sub_container'       => 'span',
+			'heading_sub_container_class' => 'pmpro_checkout-h3-name',
 		] );
 	}
 
@@ -134,10 +146,18 @@ class Member_Checkout {
 		}
 
 		pods_form_render_fields( 'pmpro_membership_user', $user ? $user->ID : null, [
-			'section_field' => 'pmpro_section_checkout',
-			'section'       => 'after_pricing_fields',
-			'render'        => 'div-rows',
-			'heading'       => 'h3',
+			'section_field'               => 'pmpro_section_checkout',
+			'section'                     => 'after_pricing_fields',
+			'render'                      => 'div-rows',
+			'wrapper'                     => true,
+			'wrapper_class'               => [
+				'pmpro_checkout',
+				__FUNCTION__,
+			],
+			'container_class'             => 'pmpro_checkout-fields',
+			'heading'                     => 'h3',
+			'heading_sub_container'       => 'span',
+			'heading_sub_container_class' => 'pmpro_checkout-h3-name',
 		] );
 	}
 
@@ -205,6 +225,62 @@ class Member_Checkout {
 	}
 
 	/**
+	 * Render the fields for the checkout page in the after user fields section.
+	 *
+	 * @since 1.0.2
+	 *
+	 * @param WP_User|null $user The user object.
+	 */
+	public function pmpro_checkout_after_user_fields( $user = null ) {
+		if ( ! empty( $GLOBALS['pmpro_review'] ) ) {
+			return;
+		}
+
+		pods_form_render_fields( 'pmpro_membership_user', $user ? $user->ID : null, [
+			'section_field'               => 'pmpro_section_checkout',
+			'section'                     => 'after_user_fields',
+			'render'                      => 'div-rows',
+			'wrapper'                     => true,
+			'wrapper_class'               => [
+				'pmpro_checkout',
+				'pmpro-pods--' . __FUNCTION__,
+			],
+			'container_class'             => 'pmpro_checkout-fields',
+			'heading'                     => 'h3',
+			'heading_sub_container'       => 'span',
+			'heading_sub_container_class' => 'pmpro_checkout-h3-name',
+		] );
+	}
+
+	/**
+	 * Render the fields for the checkout page in the checkout boxes section.
+	 *
+	 * @since 1.0.2
+	 *
+	 * @param WP_User|null $user The user object or null if not provided.
+	 */
+	public function pmpro_checkout_boxes( $user = null ) {
+		if ( ! empty( $GLOBALS['pmpro_review'] ) ) {
+			return;
+		}
+
+		pods_form_render_fields( 'pmpro_membership_user', $user ? $user->ID : null, [
+			'section_field'               => 'pmpro_section_checkout',
+			'section'                     => 'boxes',
+			'render'                      => 'div-rows',
+			'wrapper'                     => true,
+			'wrapper_class'               => [
+				'pmpro_checkout',
+				__FUNCTION__,
+			],
+			'container_class'             => 'pmpro_checkout-fields',
+			'heading'                     => 'h3',
+			'heading_sub_container'       => 'span',
+			'heading_sub_container_class' => 'pmpro_checkout-h3-name',
+		] );
+	}
+
+	/**
 	 * Render the fields for the checkout page in the after billing fields section.
 	 *
 	 * @since 1.0.0
@@ -217,10 +293,18 @@ class Member_Checkout {
 		}
 
 		pods_form_render_fields( 'pmpro_membership_user', $user ? $user->ID : null, [
-			'section_field' => 'pmpro_section_checkout',
-			'section'       => 'after_billing_fields',
-			'render'        => 'div-rows',
-			'heading'       => 'h3',
+			'section_field'               => 'pmpro_section_checkout',
+			'section'                     => 'after_billing_fields',
+			'render'                      => 'div-rows',
+			'wrapper'                     => true,
+			'wrapper_class'               => [
+				'pmpro_checkout',
+				__FUNCTION__,
+			],
+			'container_class'             => 'pmpro_checkout-fields',
+			'heading'                     => 'h3',
+			'heading_sub_container'       => 'span',
+			'heading_sub_container_class' => 'pmpro_checkout-h3-name',
 		] );
 	}
 
@@ -237,10 +321,18 @@ class Member_Checkout {
 		}
 
 		pods_form_render_fields( 'pmpro_membership_user', $user ? $user->ID : null, [
-			'section_field' => 'pmpro_section_checkout',
-			'section'       => 'after_payment_information_fields',
-			'render'        => 'div-rows',
-			'heading'       => 'h3',
+			'section_field'               => 'pmpro_section_checkout',
+			'section'                     => 'after_payment_information_fields',
+			'render'                      => 'div-rows',
+			'wrapper'                     => true,
+			'wrapper_class'               => [
+				'pmpro_checkout',
+				__FUNCTION__,
+			],
+			'container_class'             => 'pmpro_checkout-fields',
+			'heading'                     => 'h3',
+			'heading_sub_container'       => 'span',
+			'heading_sub_container_class' => 'pmpro_checkout-h3-name',
 		] );
 	}
 
@@ -257,10 +349,18 @@ class Member_Checkout {
 		}
 
 		pods_form_render_fields( 'pmpro_membership_user', $user ? $user->ID : null, [
-			'section_field' => 'pmpro_section_checkout',
-			'section'       => 'after_tos_fields',
-			'render'        => 'div-rows',
-			'heading'       => 'h3',
+			'section_field'               => 'pmpro_section_checkout',
+			'section'                     => 'after_tos_fields',
+			'render'                      => 'div-rows',
+			'wrapper'                     => true,
+			'wrapper_class'               => [
+				'pmpro_checkout',
+				__FUNCTION__,
+			],
+			'container_class'             => 'pmpro_checkout-fields',
+			'heading'                     => 'h3',
+			'heading_sub_container'       => 'span',
+			'heading_sub_container_class' => 'pmpro_checkout-h3-name',
 		] );
 	}
 
@@ -277,10 +377,18 @@ class Member_Checkout {
 		}
 
 		pods_form_render_fields( 'pmpro_membership_user', $user ? $user->ID : null, [
-			'section_field' => 'pmpro_section_checkout',
-			'section'       => 'after_captcha',
-			'render'        => 'div-rows',
-			'heading'       => 'h3',
+			'section_field'               => 'pmpro_section_checkout',
+			'section'                     => 'after_captcha',
+			'render'                      => 'div-rows',
+			'wrapper'                     => true,
+			'wrapper_class'               => [
+				'pmpro_checkout',
+				__FUNCTION__,
+			],
+			'container_class'             => 'pmpro_checkout-fields',
+			'heading'                     => 'h3',
+			'heading_sub_container'       => 'span',
+			'heading_sub_container_class' => 'pmpro_checkout-h3-name',
 		] );
 	}
 
@@ -297,10 +405,18 @@ class Member_Checkout {
 		}
 
 		pods_form_render_fields( 'pmpro_membership_user', $user ? $user->ID : null, [
-			'section_field' => 'pmpro_section_checkout',
-			'section'       => 'before_submit_button',
-			'render'        => 'div-rows',
-			'heading'       => 'h3',
+			'section_field'               => 'pmpro_section_checkout',
+			'section'                     => 'before_submit_button',
+			'render'                      => 'div-rows',
+			'wrapper'                     => true,
+			'wrapper_class'               => [
+				'pmpro_checkout',
+				__FUNCTION__,
+			],
+			'container_class'             => 'pmpro_checkout-fields',
+			'heading'                     => 'h3',
+			'heading_sub_container'       => 'span',
+			'heading_sub_container_class' => 'pmpro_checkout-h3-name',
 		] );
 	}
 

--- a/src/PMPro/Objects/Member_Checkout.php
+++ b/src/PMPro/Objects/Member_Checkout.php
@@ -110,9 +110,9 @@ class Member_Checkout {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param WP_User $user The user object.
+	 * @param WP_User|null $user The user object or null if not provided.
 	 */
-	public function pmpro_checkout_after_level_cost( $user ) {
+	public function pmpro_checkout_after_level_cost( $user = null ) {
 		if ( ! empty( $GLOBALS['pmpro_review'] ) ) {
 			return;
 		}
@@ -138,9 +138,9 @@ class Member_Checkout {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param WP_User $user The user object.
+	 * @param WP_User|null $user The user object or null if not provided.
 	 */
-	public function pmpro_checkout_after_pricing_fields( $user ) {
+	public function pmpro_checkout_after_pricing_fields( $user = null ) {
 		if ( ! empty( $GLOBALS['pmpro_review'] ) ) {
 			return;
 		}
@@ -166,9 +166,9 @@ class Member_Checkout {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param WP_User $user The user object.
+	 * @param WP_User|null $user The user object or null if not provided.
 	 */
-	public function pmpro_checkout_after_username( $user ) {
+	public function pmpro_checkout_after_username( $user = null ) {
 		if ( ! empty( $GLOBALS['pmpro_review'] ) ) {
 			return;
 		}
@@ -187,9 +187,9 @@ class Member_Checkout {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param WP_User $user The user object.
+	 * @param WP_User|null $user The user object or null if not provided.
 	 */
-	public function pmpro_checkout_after_password( $user ) {
+	public function pmpro_checkout_after_password( $user = null ) {
 		if ( ! empty( $GLOBALS['pmpro_review'] ) ) {
 			return;
 		}
@@ -208,9 +208,9 @@ class Member_Checkout {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param WP_User $user The user object.
+	 * @param WP_User|null $user The user object or null if not provided.
 	 */
-	public function pmpro_checkout_after_email( $user ) {
+	public function pmpro_checkout_after_email( $user = null ) {
 		if ( ! empty( $GLOBALS['pmpro_review'] ) ) {
 			return;
 		}
@@ -285,9 +285,9 @@ class Member_Checkout {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param WP_User $user The user object.
+	 * @param WP_User|null $user The user object or null if not provided.
 	 */
-	public function pmpro_checkout_after_billing_fields( $user ) {
+	public function pmpro_checkout_after_billing_fields( $user = null ) {
 		if ( ! empty( $GLOBALS['pmpro_review'] ) ) {
 			return;
 		}
@@ -313,9 +313,9 @@ class Member_Checkout {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param WP_User $user The user object.
+	 * @param WP_User|null $user The user object or null if not provided.
 	 */
-	public function pmpro_checkout_after_payment_information_fields( $user ) {
+	public function pmpro_checkout_after_payment_information_fields( $user = null ) {
 		if ( ! empty( $GLOBALS['pmpro_review'] ) ) {
 			return;
 		}
@@ -341,9 +341,9 @@ class Member_Checkout {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param WP_User $user The user object.
+	 * @param WP_User|null $user The user object or null if not provided.
 	 */
-	public function pmpro_checkout_after_tos_fields( $user ) {
+	public function pmpro_checkout_after_tos_fields( $user = null ) {
 		if ( ! empty( $GLOBALS['pmpro_review'] ) ) {
 			return;
 		}
@@ -369,9 +369,9 @@ class Member_Checkout {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param WP_User $user The user object.
+	 * @param WP_User|null $user The user object or null if not provided.
 	 */
-	public function pmpro_checkout_after_captcha( $user ) {
+	public function pmpro_checkout_after_captcha( $user = null ) {
 		if ( ! empty( $GLOBALS['pmpro_review'] ) ) {
 			return;
 		}
@@ -397,9 +397,9 @@ class Member_Checkout {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param WP_User $user The user object.
+	 * @param WP_User|null $user The user object or null if not provided.
 	 */
-	public function pmpro_checkout_before_submit_button( $user ) {
+	public function pmpro_checkout_before_submit_button( $user = null ) {
 		if ( ! empty( $GLOBALS['pmpro_review'] ) ) {
 			return;
 		}
@@ -437,8 +437,8 @@ class Member_Checkout {
 
 		$is_valid = pods_form_validate_submitted_fields( 'pmpro_membership_user' );
 
-		// Check if it passes validation.
-		if ( true === $is_valid ) {
+		// Check if it passes validation or the Pod doesn't exist.
+		if ( true === $is_valid || null === $is_valid ) {
 			return true;
 		}
 

--- a/src/Pods/Integration.php
+++ b/src/Pods/Integration.php
@@ -538,6 +538,10 @@ class Integration {
 					'after_password'                   => __( 'After Password (no heading)', 'pmpro-pods' ),
 					// After Password (no heading) [after_password]
 					'after_email'                      => __( 'After Email (no heading)', 'pmpro-pods' ),
+					// After User
+					'after_user_fields'                => __( 'After User Fields', 'pmpro-pods' ),
+					// After Checkout Boxes [after_user_fields]
+					'boxes'                            => __( 'Checkout Boxes', 'pmpro-pods' ),
 					// After Email (no heading) [after_email]
 					'after_billing_fields'             => __( 'After Billing Fields', 'pmpro-pods' ),
 					// After Billing Fields [after_billing_fields]


### PR DESCRIPTION
# Changelog

* ENHANCEMENT: Added support for two new locations on the PMPro checkout page: After User Fields and Checkout Boxes. (@sc0ttkclark)
* BUG FIX: Improved appearance of Pods fields on the PMPro checkout page so they more closely match styles used by PMPro. (@sc0ttkclark)
* BUG FIX: Prevent PHP notices from usage of certain PMPro hooks when `$user` object is not passed in. (@sc0ttkclark)
* BUG FIX: Prevent PHP notices on the PMPro checkout page when the PMPro Member pod does not exist and has not yet been extended. (@sc0ttkclark)