### PR TITLE
Fixing field saving on "add member" page

### DIFF
--- a/src/PMPro/Objects/Member_Checkout.php
+++ b/src/PMPro/Objects/Member_Checkout.php
@@ -73,6 +73,9 @@ class Member_Checkout {
 		add_action( 'pmpro_before_send_to_payfast', [ $this, 'save_checkout_data' ], 20, 2 );
 
 		add_filter( 'pmpro_registration_checks', [ $this, 'pmpro_registration_checks' ] );
+
+		// Compatibility for PMPro Add Member Add On. Param 2 is expected to be $order, but it is never used.
+		add_action( 'pmpro_add_member_added', [ $this, 'pmpro_after_checkout' ], 10, 2 );
 	}
 
 	/**
@@ -103,6 +106,9 @@ class Member_Checkout {
 		remove_action( 'pmpro_before_send_to_payfast', [ $this, 'save_checkout_data' ], 20, 2 );
 
 		remove_filter( 'pmpro_registration_checks', [ $this, 'pmpro_registration_checks' ] );
+
+		// Compatibility for PMPro Add Member Add On.
+		remove_action( 'pmpro_add_member_added', [ $this, 'pmpro_after_checkout' ], 10, 2 );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pods/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pods/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixes issue where PODS fields would not save on "Add Member" page

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Activate PMPro Add Member
2. Set up PMPro Pods with fields for Members
3. Add a new user from the "Memerships > Add Member" page and fill out the custom field. See does it does not save before change, but does after.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
