### PR TITLE
Updating headings hierarchy to match new PMPro checkout page for a11y

### DIFF
--- a/src/PMPro/Objects/Member_Checkout.php
+++ b/src/PMPro/Objects/Member_Checkout.php
@@ -22,7 +22,7 @@ use WP_User;
  *
  * Markup:
  *        <hr />
- *        <h3>Group label</h3>
+ *        <h2>Group label</h2>
  *        <table class="form-table">
  *
  * Save hook:
@@ -127,9 +127,9 @@ class Member_Checkout {
 				__FUNCTION__,
 			],
 			'container_class'             => 'pmpro_checkout-fields',
-			'heading'                     => 'h3',
+			'heading'                     => 'h2',
 			'heading_sub_container'       => 'span',
-			'heading_sub_container_class' => 'pmpro_checkout-h3-name',
+			'heading_sub_container_class' => 'pmpro_checkout-h2-name',
 		] );
 	}
 
@@ -155,9 +155,9 @@ class Member_Checkout {
 				__FUNCTION__,
 			],
 			'container_class'             => 'pmpro_checkout-fields',
-			'heading'                     => 'h3',
+			'heading'                     => 'h2',
 			'heading_sub_container'       => 'span',
-			'heading_sub_container_class' => 'pmpro_checkout-h3-name',
+			'heading_sub_container_class' => 'pmpro_checkout-h2-name',
 		] );
 	}
 
@@ -246,9 +246,9 @@ class Member_Checkout {
 				'pmpro-pods--' . __FUNCTION__,
 			],
 			'container_class'             => 'pmpro_checkout-fields',
-			'heading'                     => 'h3',
+			'heading'                     => 'h2',
 			'heading_sub_container'       => 'span',
-			'heading_sub_container_class' => 'pmpro_checkout-h3-name',
+			'heading_sub_container_class' => 'pmpro_checkout-h2-name',
 		] );
 	}
 
@@ -274,9 +274,9 @@ class Member_Checkout {
 				__FUNCTION__,
 			],
 			'container_class'             => 'pmpro_checkout-fields',
-			'heading'                     => 'h3',
+			'heading'                     => 'h2',
 			'heading_sub_container'       => 'span',
-			'heading_sub_container_class' => 'pmpro_checkout-h3-name',
+			'heading_sub_container_class' => 'pmpro_checkout-h2-name',
 		] );
 	}
 
@@ -302,9 +302,9 @@ class Member_Checkout {
 				__FUNCTION__,
 			],
 			'container_class'             => 'pmpro_checkout-fields',
-			'heading'                     => 'h3',
+			'heading'                     => 'h2',
 			'heading_sub_container'       => 'span',
-			'heading_sub_container_class' => 'pmpro_checkout-h3-name',
+			'heading_sub_container_class' => 'pmpro_checkout-h2-name',
 		] );
 	}
 
@@ -330,9 +330,9 @@ class Member_Checkout {
 				__FUNCTION__,
 			],
 			'container_class'             => 'pmpro_checkout-fields',
-			'heading'                     => 'h3',
+			'heading'                     => 'h2',
 			'heading_sub_container'       => 'span',
-			'heading_sub_container_class' => 'pmpro_checkout-h3-name',
+			'heading_sub_container_class' => 'pmpro_checkout-h2-name',
 		] );
 	}
 
@@ -358,9 +358,9 @@ class Member_Checkout {
 				__FUNCTION__,
 			],
 			'container_class'             => 'pmpro_checkout-fields',
-			'heading'                     => 'h3',
+			'heading'                     => 'h2',
 			'heading_sub_container'       => 'span',
-			'heading_sub_container_class' => 'pmpro_checkout-h3-name',
+			'heading_sub_container_class' => 'pmpro_checkout-h2-name',
 		] );
 	}
 
@@ -386,9 +386,9 @@ class Member_Checkout {
 				__FUNCTION__,
 			],
 			'container_class'             => 'pmpro_checkout-fields',
-			'heading'                     => 'h3',
+			'heading'                     => 'h2',
 			'heading_sub_container'       => 'span',
-			'heading_sub_container_class' => 'pmpro_checkout-h3-name',
+			'heading_sub_container_class' => 'pmpro_checkout-h2-name',
 		] );
 	}
 
@@ -414,9 +414,9 @@ class Member_Checkout {
 				__FUNCTION__,
 			],
 			'container_class'             => 'pmpro_checkout-fields',
-			'heading'                     => 'h3',
+			'heading'                     => 'h2',
 			'heading_sub_container'       => 'span',
-			'heading_sub_container_class' => 'pmpro_checkout-h3-name',
+			'heading_sub_container_class' => 'pmpro_checkout-h2-name',
 		] );
 	}
 

--- a/src/PMPro/Objects/Member_Profile.php
+++ b/src/PMPro/Objects/Member_Profile.php
@@ -15,12 +15,12 @@ namespace PMPro_Pods\PMPro\Objects;
  *
  * Markup:
  *		<hr />
- *		<h3>Group label</h3>
+ *		<h2>Group label</h2>
  *		<table class="form-table">
  *
  * Markup (pmpro_show_user_profile):
  *		<hr />
- *		<h3>Group label</h3>
+ *		<h2>Group label</h2>
  *		<div ...>
  *
  * Save hook:
@@ -91,7 +91,7 @@ class Member_Profile {
 			'section_field' => 'pmpro_section_member_profile',
 			'section'       => 'show_on_front',
 			'render'        => 'div-rows',
-			'heading'       => 'h3',
+			'heading'       => 'h2',
 			'separator'     => 'off',
 		] );
 	}
@@ -160,7 +160,7 @@ class Member_Profile {
 			'section_field'     => 'pmpro_section_member_profile',
 			'section'           => 'show_on_front',
 			'render'            => 'table-separated',
-			'heading'           => 'h3',
+			'heading'           => 'h2',
 			'separated_heading' => __( 'Order Information', 'pmpro-pods' ),
 			'separator'         => 'off',
 		] );
@@ -177,7 +177,7 @@ class Member_Profile {
 		pods_form_render_fields( 'pmpro_membership_user', $user->ID, [
 			'section_field' => 'pmpro_section_member_profile',
 			'section'       => 'show_on_admin',
-			'heading'       => 'h3',
+			'heading'       => 'h2',
 		] );
 	}
 
@@ -192,7 +192,7 @@ class Member_Profile {
 		pods_form_render_fields( 'pmpro_membership_user', $user->ID, [
 			'section_field' => 'pmpro_section_member_profile',
 			'section'       => 'show_on_admin',
-			'heading'       => 'h3',
+			'heading'       => 'h2',
 		] );
 	}
 


### PR DESCRIPTION
PMPro v2.11 updated the checkout page headings hierarchy from h3 to h2. This PR updates this Add On to follow the same pattern for accessibility.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pods/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pods/pulls/) for the same update/change?

### Changelog entry

> Updating headings hierarchy to match new PMPro checkout page for a11y