### PR TITLE
Allow rendering current field values on checkout if user is logged in

### DIFF
--- a/src/PMPro/Objects/Member_Checkout.php
+++ b/src/PMPro/Objects/Member_Checkout.php
@@ -115,15 +115,15 @@ class Member_Checkout {
 	 * Render the fields for the checkout page in the after level cost section.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @param WP_User|null $user The user object or null if not provided.
 	 */
-	public function pmpro_checkout_after_level_cost( $user = null ) {
+	public function pmpro_checkout_after_level_cost() {
 		if ( ! empty( $GLOBALS['pmpro_review'] ) ) {
 			return;
 		}
 
-		pods_form_render_fields( 'pmpro_membership_user', $user ? $user->ID : null, [
+		$user_id = is_user_logged_in() ? get_current_user_id() : null;
+
+		pods_form_render_fields( 'pmpro_membership_user', $user_id, [
 			'section_field'               => 'pmpro_section_checkout',
 			'section'                     => 'after_level_cost',
 			'render'                      => 'div-rows',
@@ -143,15 +143,15 @@ class Member_Checkout {
 	 * Render the fields for the checkout page in the after pricing fields section.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @param WP_User|null $user The user object or null if not provided.
 	 */
-	public function pmpro_checkout_after_pricing_fields( $user = null ) {
+	public function pmpro_checkout_after_pricing_fields() {
 		if ( ! empty( $GLOBALS['pmpro_review'] ) ) {
 			return;
 		}
 
-		pods_form_render_fields( 'pmpro_membership_user', $user ? $user->ID : null, [
+		$user_id = is_user_logged_in() ? get_current_user_id() : null;
+
+		pods_form_render_fields( 'pmpro_membership_user', $user_id, [
 			'section_field'               => 'pmpro_section_checkout',
 			'section'                     => 'after_pricing_fields',
 			'render'                      => 'div-rows',
@@ -171,15 +171,15 @@ class Member_Checkout {
 	 * Render the fields for the checkout page in the after username section.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @param WP_User|null $user The user object or null if not provided.
 	 */
-	public function pmpro_checkout_after_username( $user = null ) {
+	public function pmpro_checkout_after_username() {
 		if ( ! empty( $GLOBALS['pmpro_review'] ) ) {
 			return;
 		}
 
-		pods_form_render_fields( 'pmpro_membership_user', $user ? $user->ID : null, [
+		$user_id = is_user_logged_in() ? get_current_user_id() : null;
+
+		pods_form_render_fields( 'pmpro_membership_user', $user_id, [
 			'section_field' => 'pmpro_section_checkout',
 			'section'       => 'after_username',
 			'render'        => 'div-rows',
@@ -192,15 +192,15 @@ class Member_Checkout {
 	 * Render the fields for the checkout page in the after password section.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @param WP_User|null $user The user object or null if not provided.
 	 */
-	public function pmpro_checkout_after_password( $user = null ) {
+	public function pmpro_checkout_after_password() {
 		if ( ! empty( $GLOBALS['pmpro_review'] ) ) {
 			return;
 		}
 
-		pods_form_render_fields( 'pmpro_membership_user', $user ? $user->ID : null, [
+		$user_id = is_user_logged_in() ? get_current_user_id() : null;
+
+		pods_form_render_fields( 'pmpro_membership_user', $user_id, [
 			'section_field' => 'pmpro_section_checkout',
 			'section'       => 'after_password',
 			'render'        => 'div-rows',
@@ -213,15 +213,15 @@ class Member_Checkout {
 	 * Render the fields for the checkout page in the after email section.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @param WP_User|null $user The user object or null if not provided.
 	 */
-	public function pmpro_checkout_after_email( $user = null ) {
+	public function pmpro_checkout_after_email() {
 		if ( ! empty( $GLOBALS['pmpro_review'] ) ) {
 			return;
 		}
 
-		pods_form_render_fields( 'pmpro_membership_user', $user ? $user->ID : null, [
+		$user_id = is_user_logged_in() ? get_current_user_id() : null;
+
+		pods_form_render_fields( 'pmpro_membership_user', $user_id, [
 			'section_field' => 'pmpro_section_checkout',
 			'section'       => 'after_email',
 			'render'        => 'div-rows',
@@ -242,7 +242,9 @@ class Member_Checkout {
 			return;
 		}
 
-		pods_form_render_fields( 'pmpro_membership_user', $user ? $user->ID : null, [
+		$user_id = is_user_logged_in() ? get_current_user_id() : null;
+
+		pods_form_render_fields( 'pmpro_membership_user', $user_id, [
 			'section_field'               => 'pmpro_section_checkout',
 			'section'                     => 'after_user_fields',
 			'render'                      => 'div-rows',
@@ -262,15 +264,15 @@ class Member_Checkout {
 	 * Render the fields for the checkout page in the checkout boxes section.
 	 *
 	 * @since 1.0.2
-	 *
-	 * @param WP_User|null $user The user object or null if not provided.
 	 */
-	public function pmpro_checkout_boxes( $user = null ) {
+	public function pmpro_checkout_boxes() {
 		if ( ! empty( $GLOBALS['pmpro_review'] ) ) {
 			return;
 		}
 
-		pods_form_render_fields( 'pmpro_membership_user', $user ? $user->ID : null, [
+		$user_id = is_user_logged_in() ? get_current_user_id() : null;
+
+		pods_form_render_fields( 'pmpro_membership_user', $user_id, [
 			'section_field'               => 'pmpro_section_checkout',
 			'section'                     => 'boxes',
 			'render'                      => 'div-rows',
@@ -290,15 +292,15 @@ class Member_Checkout {
 	 * Render the fields for the checkout page in the after billing fields section.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @param WP_User|null $user The user object or null if not provided.
 	 */
-	public function pmpro_checkout_after_billing_fields( $user = null ) {
+	public function pmpro_checkout_after_billing_fields() {
 		if ( ! empty( $GLOBALS['pmpro_review'] ) ) {
 			return;
 		}
 
-		pods_form_render_fields( 'pmpro_membership_user', $user ? $user->ID : null, [
+		$user_id = is_user_logged_in() ? get_current_user_id() : null;
+
+		pods_form_render_fields( 'pmpro_membership_user', $user_id, [
 			'section_field'               => 'pmpro_section_checkout',
 			'section'                     => 'after_billing_fields',
 			'render'                      => 'div-rows',
@@ -318,15 +320,15 @@ class Member_Checkout {
 	 * Render the fields for the checkout page in the after payment information fields section.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @param WP_User|null $user The user object or null if not provided.
 	 */
-	public function pmpro_checkout_after_payment_information_fields( $user = null ) {
+	public function pmpro_checkout_after_payment_information_fields() {
 		if ( ! empty( $GLOBALS['pmpro_review'] ) ) {
 			return;
 		}
 
-		pods_form_render_fields( 'pmpro_membership_user', $user ? $user->ID : null, [
+		$user_id = is_user_logged_in() ? get_current_user_id() : null;
+
+		pods_form_render_fields( 'pmpro_membership_user', $user_id, [
 			'section_field'               => 'pmpro_section_checkout',
 			'section'                     => 'after_payment_information_fields',
 			'render'                      => 'div-rows',
@@ -346,15 +348,15 @@ class Member_Checkout {
 	 * Render the fields for the checkout page in the after TOS fields section.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @param WP_User|null $user The user object or null if not provided.
 	 */
-	public function pmpro_checkout_after_tos_fields( $user = null ) {
+	public function pmpro_checkout_after_tos_fields() {
 		if ( ! empty( $GLOBALS['pmpro_review'] ) ) {
 			return;
 		}
 
-		pods_form_render_fields( 'pmpro_membership_user', $user ? $user->ID : null, [
+		$user_id = is_user_logged_in() ? get_current_user_id() : null;
+
+		pods_form_render_fields( 'pmpro_membership_user', $user_id, [
 			'section_field'               => 'pmpro_section_checkout',
 			'section'                     => 'after_tos_fields',
 			'render'                      => 'div-rows',
@@ -374,15 +376,15 @@ class Member_Checkout {
 	 * Render the fields for the checkout page in the after captcha section.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @param WP_User|null $user The user object or null if not provided.
 	 */
-	public function pmpro_checkout_after_captcha( $user = null ) {
+	public function pmpro_checkout_after_captcha() {
 		if ( ! empty( $GLOBALS['pmpro_review'] ) ) {
 			return;
 		}
 
-		pods_form_render_fields( 'pmpro_membership_user', $user ? $user->ID : null, [
+		$user_id = is_user_logged_in() ? get_current_user_id() : null;
+
+		pods_form_render_fields( 'pmpro_membership_user', $user_id, [
 			'section_field'               => 'pmpro_section_checkout',
 			'section'                     => 'after_captcha',
 			'render'                      => 'div-rows',
@@ -402,15 +404,15 @@ class Member_Checkout {
 	 * Render the fields for the checkout page in the before submit button section.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @param WP_User|null $user The user object or null if not provided.
 	 */
-	public function pmpro_checkout_before_submit_button( $user = null ) {
+	public function pmpro_checkout_before_submit_button() {
 		if ( ! empty( $GLOBALS['pmpro_review'] ) ) {
 			return;
 		}
 
-		pods_form_render_fields( 'pmpro_membership_user', $user ? $user->ID : null, [
+		$user_id = is_user_logged_in() ? get_current_user_id() : null;
+
+		pods_form_render_fields( 'pmpro_membership_user', $user_id, [
 			'section_field'               => 'pmpro_section_checkout',
 			'section'                     => 'before_submit_button',
 			'render'                      => 'div-rows',


### PR DESCRIPTION
Fixes an issue reported by Amy Masson where field values are not rendered for an existing member during checkout.

Fixes #14

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pods/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pods/pulls/) for the same update/change?

### Changes proposed in this Pull Request:

Resolve issue where custom user fields were not rendering current values for current user on checkout page. The code supported this but the PMPro actions were never updated to pass current user context. The PR just removes that expectation and calls current user information directly.

### How to test the changes in this Pull Request:

1. Have a PMPro Member pod with a group that displays fields on a checkout section + profile area and add custom fields to use.
2. Log in as a user with an existing membership (or create a new one) and set values for their custom fields.
3. For a user that has a membership level that is due for renewal go to the user's account page and click on the "Renew" link.
4. On the checkout page inspect the custom user field that is created in pods and confirm that you see the current field values rendering in the Pods fields displayed.
5. Make changes or leave the field values as-is for the Pods fields.
6. Complete the checkout process.
7. Confirm on member profile that the field values were saved as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUG FIX: Resolve issue where custom user fields were not rendering current values for current user on checkout page. (Props to @sc0ttkclark)
